### PR TITLE
NEW(options) --timeout option for all clients

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,9 +4,10 @@ require 'rake/testtask'
 # For verbose output: `rake test TESTOPTS=-v`
 # See http://ruby-doc.org/stdlib-2.0.0/libdoc/rake/rdoc/Rake/TestTask.html for more.
 
-task :default => [:test]
+task :default => [:self_test]
 
 task :test => [:unit_tests, :client_tests]
+task :self_test => [:unit_tests, :client_self_tests]
 
 desc 'Run unit tests'
 Rake::TestTask.new(:unit_tests) do |t|
@@ -24,8 +25,8 @@ Rake::TestTask.new(:client_tests) do |t|
   t.warning = true
 end
 
-desc 'Run tests with a self-started test broker.'
-task :self_test => [:unit_tests] do
+desc 'Run client tests with a self-started test broker.'
+task :client_self_tests do
   broker = IO.popen([RbConfig.ruby,  File.join("bin", "broker.rb"), "" ], :err=>[:child, :out])
   unless (ready = broker.readline) =~ /^Listening on /
     Process.kill :KILL, broker.pid

--- a/bin/broker.rb
+++ b/bin/broker.rb
@@ -143,7 +143,8 @@ class Broker < Qpid::Proton::MessagingHandler
   end
 
   def remove_stale_consumers(connection)
-    connection.each_sender { |s| unsubscribe(s) }
+    # Note extra .each needed to work around https://issues.apache.org/jira/browse/PROTON-1784
+    connection.each_sender.each { |s| unsubscribe(s) }
   end
 
   def on_sendable(sender)

--- a/lib/connector_client.rb
+++ b/lib/connector_client.rb
@@ -34,7 +34,8 @@ class ConnectorClient
     connector_handler = Handlers::ConnectorHandler.new(
       connector_options_parser.options.broker,
       connector_options_parser.options.count,
-      connector_options_parser.options.sasl_mechs
+      connector_options_parser.options.sasl_mechs,
+      connector_options_parser.options.exit_timer
     )
     # Run connector client
     Qpid::Proton::Container.new(connector_handler).run

--- a/lib/handlers/basic_handler.rb
+++ b/lib/handlers/basic_handler.rb
@@ -21,6 +21,8 @@ module Handlers
   # Basic events handler for all clients
   class BasicHandler < Qpid::Proton::MessagingHandler
 
+    # Exit timer limits the run-time of the application
+    attr_accessor :exit_timer
     # URI of broker
     attr_accessor :broker
     # Allowed SASL mechs
@@ -30,8 +32,9 @@ module Handlers
     # ==== Basic events handler arguments
     # broker:: URI of broker
     # sasl_mechs: allowed SASL mechanisms
-    def initialize(broker, sasl_mechs)
+    def initialize(broker, sasl_mechs, exit_timer=nil)
       super()
+      @exit_timer = exit_timer
       # Save URI of broker
       if broker.is_a? URI::AMQP or broker.is_a? URI::AMQPS
         @broker = broker

--- a/lib/handlers/connector_handler.rb
+++ b/lib/handlers/connector_handler.rb
@@ -31,8 +31,8 @@ module Handlers
     # broker:: URI of broker
     # count:: Number of connections to create
     # sasl_mechs:: Allowed SASL mechanisms
-    def initialize(broker, count, sasl_mechs)
-      super(broker, sasl_mechs)
+    def initialize(broker, count, sasl_mechs, exit_timer=nil)
+      super(broker, sasl_mechs, exit_timer)
       # Save count of connections
       @count = count
       # Initialize array of connections
@@ -56,6 +56,10 @@ module Handlers
           sasl_allowed_mechs: @sasl_mechs
         ))
       end
+    end
+
+    def on_connection_open(c)
+      exit_timer.reset if exit_timer
     end
 
   end # class ConnectorHandler

--- a/lib/handlers/receiver_handler.rb
+++ b/lib/handlers/receiver_handler.rb
@@ -45,9 +45,10 @@ module Handlers
       count,
       process_reply_to,
       browse,
-      sasl_mechs
+      sasl_mechs,
+      exit_timer=nil
     )
-      super(broker, log_msgs, sasl_mechs)
+      super(broker, log_msgs, sasl_mechs, exit_timer)
       # Save count of messages
       @count = count
       # Save process reply to
@@ -86,6 +87,7 @@ module Handlers
     # Called when a message is received,
     # receiving ReceiverHandler#count messages
     def on_message(delivery, message)
+      exit_timer.reset if exit_timer
       # Print received message
       if @log_msgs == "body"
         Formatters::BasicFormatter.new(message).print

--- a/lib/handlers/sender_handler.rb
+++ b/lib/handlers/sender_handler.rb
@@ -60,9 +60,10 @@ module Handlers
       msg_correlation_id,
       msg_reply_to,
       msg_group_id,
-      sasl_mechs
+      sasl_mechs,
+      exit_timer=nil
     )
-      super(broker, log_msgs, sasl_mechs)
+      super(broker, log_msgs, sasl_mechs, exit_timer)
       # Save count of messages
       @count = count
       # Save message content
@@ -107,6 +108,7 @@ module Handlers
       # While sender credit is available
       # and number of sent messages is less than count
       while (sender.credit > 0) && (@sent < @count)
+        exit_timer.reset if exit_timer
         # Create new message
         msg = Qpid::Proton::Message.new
         # If message content is set

--- a/lib/handlers/sr_common_handler.rb
+++ b/lib/handlers/sr_common_handler.rb
@@ -29,8 +29,8 @@ module Handlers
     # broker:: URI of broker
     # log_msgs:: format of message(s) log
     # sasl_mechs:: allowed SASL mechanisms
-    def initialize(broker, log_msgs, sasl_mechs)
-      super(broker, sasl_mechs)
+    def initialize(broker, log_msgs, sasl_mechs, exit_timer=nil)
+      super(broker, sasl_mechs, exit_timer)
       # Save message(s) log format
       @log_msgs = log_msgs
     end

--- a/lib/options/basic_option_parser.rb
+++ b/lib/options/basic_option_parser.rb
@@ -18,6 +18,7 @@ require 'optparse'
 require 'ostruct'
 
 require_relative '../defaults'
+require_relative '../utils/exit_timer'
 
 module Options
 
@@ -56,6 +57,14 @@ module Options
         "(default: #{Defaults::DEFAULT_BROKER})"
       ) do |broker|
         @options.broker = broker
+      end
+
+      # Client exits after this timeout.
+      # Handlers can restart the timer (e.g. on receiving messages, making connections etc.)
+      @opt_parser.on("--timeout TIMEOUT", Float,
+                     "timeout in seconds to wait before exiting, 0 unlimited (default 0)"
+                    ) do |t|
+        @options.exit_timer = ExitTimer.new(t) if t > 0
       end
 
       # Allowed SASL mechanisms

--- a/lib/receiver_client.rb
+++ b/lib/receiver_client.rb
@@ -37,7 +37,8 @@ class ReceiverClient
       receiver_options_parser.options.count,
       receiver_options_parser.options.process_reply_to,
       receiver_options_parser.options.browse,
-      receiver_options_parser.options.sasl_mechs
+      receiver_options_parser.options.sasl_mechs,
+      receiver_options_parser.options.exit_timer
     )
     # Run receiver client
     Qpid::Proton::Container.new(receiver_handler).run

--- a/lib/sender_client.rb
+++ b/lib/sender_client.rb
@@ -41,7 +41,8 @@ class SenderClient
       sender_options_parser.options.msg_correlation_id,
       sender_options_parser.options.msg_reply_to,
       sender_options_parser.options.msg_group_id,
-      sender_options_parser.options.sasl_mechs
+      sender_options_parser.options.sasl_mechs,
+      sender_options_parser.options.exit_timer
     )
     # Run sender client
     Qpid::Proton::Container.new(sender_handler).run

--- a/lib/utils/exit_timer.rb
+++ b/lib/utils/exit_timer.rb
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Timer that exits the process if it expires.
+# Use a timer thread, as the Qpid::Proton::Container does not yet provide scheduled tasks.
+
+class ExitTimer
+
+  # Start the timer to exit after timeout.
+  def initialize(timeout)
+    @timeout = timeout
+    @lock = Mutex.new
+    reset
+    Thread.new do
+      while (delta = @lock.synchronize { @deadline - Time.now } ) > 0
+        sleep delta
+      end
+      puts "timeout expired"
+      exit(1)
+    end
+  end
+
+  # Reset the timer to count to timeout from now
+  def reset()
+    @lock.synchronize { @deadline = Time.now + @timeout }
+  end
+
+end


### PR DESCRIPTION
This option stops the client abruptly with a message to stdout and exit status 1
if the timeout expires before the process completes.