### PR TITLE
UPD(handlers) make `exit_timer` a mandatory option to prevent screw-ups

### DIFF
--- a/lib/handlers/basic_handler.rb
+++ b/lib/handlers/basic_handler.rb
@@ -34,7 +34,7 @@ module Handlers
     # ==== Basic events handler arguments
     # broker:: URI of broker
     # sasl_mechs: allowed SASL mechanisms
-    def initialize(broker, sasl_mechs, idle_timeout, exit_timer=nil)
+    def initialize(broker, sasl_mechs, idle_timeout, exit_timer)
       super()
       @exit_timer = exit_timer
       # Save URI of broker

--- a/lib/handlers/connector_handler.rb
+++ b/lib/handlers/connector_handler.rb
@@ -31,7 +31,7 @@ module Handlers
     # broker:: URI of broker
     # count:: Number of connections to create
     # sasl_mechs:: Allowed SASL mechanisms
-    def initialize(broker, count, sasl_mechs, idle_timeout, exit_timer=nil)
+    def initialize(broker, count, sasl_mechs, idle_timeout, exit_timer)
       super(broker, sasl_mechs, idle_timeout, exit_timer)
       # Save count of connections
       @count = count

--- a/lib/handlers/receiver_handler.rb
+++ b/lib/handlers/receiver_handler.rb
@@ -47,7 +47,7 @@ module Handlers
       browse,
       sasl_mechs,
       idle_timeout,
-      exit_timer=nil
+      exit_timer
     )
       super(broker, log_msgs, sasl_mechs, idle_timeout, exit_timer)
       # Save count of expected messages to be received

--- a/lib/handlers/sender_handler.rb
+++ b/lib/handlers/sender_handler.rb
@@ -80,7 +80,7 @@ module Handlers
       msg_subject,
       sasl_mechs,
       idle_timeout,
-      exit_timer=nil
+      exit_timer
     )
       super(broker, log_msgs, sasl_mechs, idle_timeout, exit_timer)
       # Save count of messages to be send

--- a/lib/handlers/sr_common_handler.rb
+++ b/lib/handlers/sr_common_handler.rb
@@ -31,8 +31,7 @@ module Handlers
     # broker:: URI of broker
     # log_msgs:: format of message(s) log
     # sasl_mechs:: allowed SASL mechanisms
-    def initialize(broker, log_msgs, sasl_mechs, idle_timeout, exit_timer=nil)
-      super(broker, sasl_mechs, exit_timer)
+    def initialize(broker, log_msgs, sasl_mechs, idle_timeout, exit_timer)
       super(broker, sasl_mechs, idle_timeout, exit_timer)
       # Save message(s) log format
       @log_msgs = log_msgs


### PR DESCRIPTION
It is very easy to forgot to update parameter list for a handler
when adding an option. When there is optional parameter, then
Ruby will not report parameter count mismatch when the parameter
is omitted in a call.

Making all parameters mandatory should help finding these mistakes.