### PR TITLE
WORKAROUND(defaults) PROTON-1809 [python, ruby] Unable to receive mes…

### DIFF
--- a/lib/defaults.rb
+++ b/lib/defaults.rb
@@ -64,7 +64,7 @@ module Defaults
   # Default minimal max frame size
   DEFAULT_MIN_MAX_FRAME_SIZE = 512
   # Default maximal max frame size
-  DEFAULT_MAX_MAX_FRAME_SIZE = 4294967295
+  DEFAULT_MAX_MAX_FRAME_SIZE = 2**20  # TODO(jdanek): workaround PROTON-1809 Unable to receive messages ...
   # Default value for max frame size
   DEFAULT_MAX_FRAME_SIZE     = DEFAULT_MAX_MAX_FRAME_SIZE
 


### PR DESCRIPTION
…sages when max-frame-size is set to more than 2^20