### PR TITLE
FIX escape_chars in dTests formatters, so that output does not contain \0

### DIFF
--- a/lib/formatters/basic_formatter.rb
+++ b/lib/formatters/basic_formatter.rb
@@ -89,6 +89,22 @@ module Formatters
       puts format_value(@msg_content_hashed ? StringUtils.sha1_hash(@message.body) : @message.body)
     end # print()
 
+    # Escapes characters which Python's eval() cannot load
+    # that is esp. \0, \r, \n. Use a range, to be safe.
+    def self.escape_chars(msg_string)
+      if msg_string.nil?
+        nil
+      else
+        msg_string.each_codepoint.map do |s|
+          if s < 32 || s > 126
+            format('\\u%04x', s)
+          else
+            s.chr
+          end
+        end.join
+      end
+    end
+
   end # class BasicFormatter
 
 end # module Formatters

--- a/lib/formatters/dict_formatter.rb
+++ b/lib/formatters/dict_formatter.rb
@@ -50,7 +50,7 @@ module Formatters
       + "'content': #{
         format_value(@msg_content_hashed ? StringUtils.sha1_hash(@message.body) : @message.body)
       }"
-      return "{#{dict_to_return}}"
+      return self.class.escape_chars("{#{dict_to_return}}")
     end # get_as_dictionary()
 
     # Prints message formatted as dictionary to stdout

--- a/lib/formatters/interop_formatter.rb
+++ b/lib/formatters/interop_formatter.rb
@@ -73,7 +73,7 @@ module Formatters
       + "'content': #{
         format_value(@msg_content_hashed ? StringUtils.sha1_hash(@message.body) : @message.body)
       }"
-      return "{#{dict_to_return}}"
+      return self.class.escape_chars("{#{dict_to_return}}")
     end # get_as_interop_dictionary()
 
     # Prints message formatted as interop dictionary to stdout

--- a/tests/unit/formatters/unit_tests_basic_formatter.rb
+++ b/tests/unit/formatters/unit_tests_basic_formatter.rb
@@ -222,6 +222,12 @@ class UnitTestsBasicFormatter < Minitest::Test
     assert_equal(hashed_value, $stdout.string)
   end # test_basic_formatter_hashed_content
 
+  def test_escape
+    assert_equal("some message", Formatters::BasicFormatter.escape_chars("some message"))
+    assert_equal("a\\u0000b\\u000ac", Formatters::BasicFormatter.escape_chars("a\0b\nc"))
+    assert_equal("'a\\'b'", Formatters::BasicFormatter.escape_chars("'a\\'b'"))
+  end # test_basic_formatter_hashed_content
+
 end # class UnitTestsBasicFormatter
 
 # eof


### PR DESCRIPTION
The problem with original PR and with use of inspect was that there is already escaping introduced in `BasicFormatter#format_value(value)`, such as

    when String
        value.size > 0 ? "'#{value.gsub(/'/, %q(\\\'))}'" : "None"

Applying .inspect to this will create a bloody mess, in some cases (when there was originally some apostrophe, namely). Solution seems to be not to escape "safe" characters here, and focus only on things out of the safe range.